### PR TITLE
Remove `--allow-dirty` option (v2) …

### DIFF
--- a/.github/workflows/deploy_cargo_cyclonedx.yml
+++ b/.github/workflows/deploy_cargo_cyclonedx.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: JQ
+      - name: Install JQ
         run: |
           sudo apt-get install -y jq
       - uses: actions/checkout@v4
@@ -20,18 +20,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Cargo bump
+      - name: Cargo set-version --bump
         run: |
           cargo install cargo-edit
           cargo set-version --package cargo-cyclonedx --bump ${{ github.event.inputs.releaseType }}
-      - name: Retrieve new version
+      - name: Retrieve new version number
         run: |
           echo "::set-output name=CARGO_VERSION::$(cargo metadata | jq -r '.packages[] | select(.name == "cargo-cyclonedx") | .version')"
         id: version
-      - name: Build one time, for sanity
-        run: cargo build
-      - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose --allow-dirty
+      - name: Package once (for failing this CI job if packaging fails and for rewiting the TOML file etc.)
+        run: cargo package --package cargo-cyclonedx --verbose --allow-dirty
       - name: Configure git and add files
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -39,3 +37,6 @@ jobs:
           git commit -am "New development bump of cargo-cylonedx to ${{steps.version.outputs.CARGO_VERSION}}"
           git tag -a "cargo-cyclonedx-${{steps.version.outputs.CARGO_VERSION}}" -m "cargo-cyclonedx ${{steps.version.outputs.CARGO_VERSION}} release"
           git push --follow-tags
+      - name: Publish crate (which unconditionally recreates the package)
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose
+

--- a/.github/workflows/deploy_cargo_cyclonedx.yml
+++ b/.github/workflows/deploy_cargo_cyclonedx.yml
@@ -37,6 +37,6 @@ jobs:
           git commit -am "New development bump of cargo-cylonedx to ${{steps.version.outputs.CARGO_VERSION}}"
           git tag -a "cargo-cyclonedx-${{steps.version.outputs.CARGO_VERSION}}" -m "cargo-cyclonedx ${{steps.version.outputs.CARGO_VERSION}} release"
           git push --follow-tags
-      - name: Publish crate (which unconditionally recreates the package, but build testing again is omitted--no-verify)
+      - name: Publish crate (which unconditionally recreates the package, but build testing again is omitted)
         run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose --no-verify
 

--- a/.github/workflows/deploy_cargo_cyclonedx.yml
+++ b/.github/workflows/deploy_cargo_cyclonedx.yml
@@ -37,6 +37,6 @@ jobs:
           git commit -am "New development bump of cargo-cylonedx to ${{steps.version.outputs.CARGO_VERSION}}"
           git tag -a "cargo-cyclonedx-${{steps.version.outputs.CARGO_VERSION}}" -m "cargo-cyclonedx ${{steps.version.outputs.CARGO_VERSION}} release"
           git push --follow-tags
-      - name: Publish crate (which unconditionally recreates the package)
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose
+      - name: Publish crate (which unconditionally recreates the package, but build testing again is omitted--no-verify)
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose --no-verify
 

--- a/.github/workflows/deploy_cyclonedx_bom.yml
+++ b/.github/workflows/deploy_cyclonedx_bom.yml
@@ -40,6 +40,6 @@ jobs:
           git commit -am "New development bump of cyclonedx-bom to ${{steps.version.outputs.CARGO_VERSION}}"
           git tag -a "cyclonedx-bom-${{steps.version.outputs.CARGO_VERSION}}" -m "cyclonedx-bom ${{steps.version.outputs.CARGO_VERSION}} release"
           git push --follow-tags
-      - name: Publish crate (which unconditionally recreates the package)
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose
+      - name: Publish crate (which unconditionally recreates the package, but build testing again is omitted)
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose --no-verify
 

--- a/.github/workflows/deploy_cyclonedx_bom.yml
+++ b/.github/workflows/deploy_cyclonedx_bom.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: JQ
+      - name: Install JQ
         run: |
           sudo apt-get install -y jq
       - uses: actions/checkout@v4
@@ -23,18 +23,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Cargo bump
+      - name: Cargo set-version --bump
         run: |
           cargo install cargo-edit
           cargo set-version --package cyclonedx-bom --bump ${{ github.event.inputs.releaseType }}
-      - name: Retrieve new version
+      - name: Retrieve new version number
         run: |
           echo "::set-output name=CARGO_VERSION::$(cargo metadata | jq -r '.packages[] | select(.name == "cyclonedx-bom") | .version')"
         id: version
-      - name: Build one time, for sanity
-        run: cargo build
-      - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose --allow-dirty
+      - name: Package once (for failing this CI job if packaging fails and for rewiting the TOML file etc.)
+        run: cargo package --package cyclonedx-bom --verbose --allow-dirty
       - name: Configure git and add files
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -42,3 +40,6 @@ jobs:
           git commit -am "New development bump of cyclonedx-bom to ${{steps.version.outputs.CARGO_VERSION}}"
           git tag -a "cyclonedx-bom-${{steps.version.outputs.CARGO_VERSION}}" -m "cyclonedx-bom ${{steps.version.outputs.CARGO_VERSION}} release"
           git push --follow-tags
+      - name: Publish crate (which unconditionally recreates the package)
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose
+


### PR DESCRIPTION
… from `cargo publish` calls in the CI/CD workflows, because this option prevents creating a `.cargo_vcs_info.json` file.  This should (really) close https://github.com/rust-lang/crates.io/issues/8551 , see there for details.
Signed-off-by: olf <Olf0@users.noreply.github.com>